### PR TITLE
Adding support for encoding Unicode Astral characters included in Uri parts

### DIFF
--- a/jersey-core/src/main/java/com/sun/jersey/api/uri/UriComponent.java
+++ b/jersey-core/src/main/java/com/sun/jersey/api/uri/UriComponent.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/jersey-tests/src/test/java/com/sun/jersey/impl/uri/UriComponentDecodeTest.java
+++ b/jersey-tests/src/test/java/com/sun/jersey/impl/uri/UriComponentDecodeTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2013 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/jersey-tests/src/test/java/com/sun/jersey/impl/uri/UriComponentEncodeTest.java
+++ b/jersey-tests/src/test/java/com/sun/jersey/impl/uri/UriComponentEncodeTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2011 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2014 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
I've updated the URL encoding algorithm so that it iterates over code points (ints) instead of code units (chars). This means that characters in the Basic Multilingual Plane are encoded just fine (http://codepoints.net/basic_multilingual_plane), but characters outside of the BMP are always incorrectly encoded as %3F%3F.
