### PR TITLE
Remove bundled JAX-RS interfaces

### DIFF
--- a/jersey-core/pom.xml
+++ b/jersey-core/pom.xml
@@ -57,7 +57,6 @@
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
             <version>1.1.1</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>
@@ -168,44 +167,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin> <!-- unpack sources from jsr311-api.jar -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>javax.ws.rs</groupId>
-                                    <artifactId>jsr311-api</artifactId>
-                                    <version>1.1.1</version>
-                                    <type>jar</type>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/generated-sources/jsr311</outputDirectory>
-                                    <!--excludes>
-                                        **/CacheControl.java,
-                                        **/Cookie.java,
-                                        **/EntityTag.java,
-                                        **/MediaType.java,
-                                        **/NewCookie.java,
-                                        **/Variant.java,
-                                        **/Response.java,
-                                        **/UriBuilder.java
-                                    </excludes-->
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
 
             <plugin>
                 <groupId>com.sun.istack</groupId>


### PR DESCRIPTION
Some apps like Netflix Ribbon use Jersey 1.x, and it means that we are stuck with JAX-RS 1.x. Can't use JAX-RS 2 libs as Jersey has JAX-RS classes inside jersey-core jar.

Solution: remove bundled JAX-RS classes and use standard Maven dependency mechanism instead. It will allow to drop in new JAX-RS 2 interfaces.