### PR TITLE
JERSEY-2709 - Wadl Maven plugin classpath resolution

### DIFF
--- a/contribs/maven-wadl-plugin/src/main/java/com/sun/jersey/wadl/GenerateWadlMojo.java
+++ b/contribs/maven-wadl-plugin/src/main/java/com/sun/jersey/wadl/GenerateWadlMojo.java
@@ -86,6 +86,8 @@ import com.sun.research.ws.wadl.Resources;
  * @author <a href="mailto:martin.grotzke@freiheit.com">Martin Grotzke</a>
  * @version $Id$
  *
+ * @requiresDependencyResolution compile+runtime
+ *
  * @goal generate
  * @phase compile
  */


### PR DESCRIPTION
This change is needed because Maven 3+ constructs the classpath differently.