### PR TITLE
Don't add "Vary: Accept-Encoding" header to the response if it's already exists

### DIFF
--- a/jersey-server/src/main/java/com/sun/jersey/api/container/filter/GZIPContentEncodingFilter.java
+++ b/jersey-server/src/main/java/com/sun/jersey/api/container/filter/GZIPContentEncodingFilter.java
@@ -143,7 +143,10 @@ public class GZIPContentEncodingFilter implements ContainerRequestFilter, Contai
     }
 
     public ContainerResponse filter(ContainerRequest request, ContainerResponse response) {
-        response.getHttpHeaders().add(HttpHeaders.VARY, HttpHeaders.ACCEPT_ENCODING); // add vary header
+
+        if (!response.getHttpHeaders().containsKey(HttpHeaders.VARY) || response.getHttpHeaders().containsKey(HttpHeaders.VARY) && !response.getHttpHeaders().get(HttpHeaders.VARY).contains(HttpHeaders.ACCEPT_ENCODING)) {
+            response.getHttpHeaders().add(HttpHeaders.VARY, HttpHeaders.ACCEPT_ENCODING); // add vary header
+        }
 
         String acceptEncoding = request.getRequestHeaders().getFirst(HttpHeaders.ACCEPT_ENCODING);
         String contentEncoding = (String) response.getHttpHeaders().getFirst(HttpHeaders.CONTENT_ENCODING);

--- a/jersey-server/src/test/java/com/sun/jersey/api/container/filter/GZIPContentEncodingFilterTest.java
+++ b/jersey-server/src/test/java/com/sun/jersey/api/container/filter/GZIPContentEncodingFilterTest.java
@@ -1,0 +1,70 @@
+package com.sun.jersey.api.container.filter;
+
+import com.sun.jersey.core.header.InBoundHeaders;
+import com.sun.jersey.server.impl.application.WebApplicationImpl;
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseWriter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Created by vadyalex (at gmail).
+ */
+public class GZIPContentEncodingFilterTest {
+
+    @Test
+    public void preventAddingMultipleVaryAcceptEncodingHeaders() throws URISyntaxException {
+        final WebApplicationImpl webApplication = new WebApplicationImpl();
+
+        final ContainerRequest request = new ContainerRequest(
+                new WebApplicationImpl(),
+                "GET",
+                new URI("base/uri"),
+                new URI("request/uri"),
+                new InBoundHeaders(),
+                null
+        );
+
+        final ContainerResponse response = new ContainerResponse(
+                webApplication,
+                request,
+                createContainerResponseWriter()
+        );
+
+        Assert.assertTrue(response.getHttpHeaders().isEmpty());
+
+        final GZIPContentEncodingFilter filter = new GZIPContentEncodingFilter();
+
+        filter.filter(request, response);
+        filter.filter(request, response);
+        filter.filter(request, response);
+
+        Assert.assertNotNull(response.getHttpHeaders());
+        Assert.assertTrue(response.getHttpHeaders().containsKey(HttpHeaders.VARY));
+        Assert.assertEquals(1, response.getHttpHeaders().get(HttpHeaders.VARY).size());
+    }
+
+    private ContainerResponseWriter createContainerResponseWriter() {
+        return new ContainerResponseWriter() {
+            @Override
+            public OutputStream writeStatusAndHeaders(long contentLength, ContainerResponse response) throws IOException {
+                return new ByteArrayOutputStream();
+            }
+
+            @Override
+            public void finish() throws IOException {
+
+            }
+        };
+    }
+
+
+}


### PR DESCRIPTION
*GZIPContentEncodingFilter* modifies response header by adding "Vary: Accept-Encoding" even if it's already exists.

This side effect behaviour may lead to nasty problems..

For example, there is an JAX-RS resource:

```java
@Path("/myResource")
public class SomeResource {

    public static final Response OK = Response.ok().build();

    @GET
    public Response doGet() {
        return OK;
    }

}
```

Because *Response* class is mutable every time *GZIPContentEncodingFilter* processes request-response containers it will add "Vary: Accept-Encoding".

Since *SomeResource.OK* lives during application lifetime header size will grow until overgrows __maximum header limit size__ allowed by underlying Servlet Container and application will not be able to process current resource.