### PR TITLE
Fix for CDI Component Initialization on IBM WebSphere 8.5.5.12 Update

### DIFF
--- a/jersey-servlet/src/main/java/com/sun/jersey/server/impl/cdi/CDIComponentProviderFactoryInitializer.java
+++ b/jersey-servlet/src/main/java/com/sun/jersey/server/impl/cdi/CDIComponentProviderFactoryInitializer.java
@@ -58,7 +58,7 @@ import java.util.logging.Logger;
  * @author robc
  */
 public class CDIComponentProviderFactoryInitializer {
-    
+
     private static final Logger LOGGER = Logger.getLogger(CDIComponentProviderFactoryInitializer.class.getName());
 
     private static final String BEAN_MANAGER_CLASS = "javax.enterprise.inject.spi.BeanManager";
@@ -73,8 +73,15 @@ public class CDIComponentProviderFactoryInitializer {
             return;
         }
 
-        rc.getSingletons().add(new CDIComponentProviderFactory(beanManager, rc, wa));
-        LOGGER.info("CDI support is enabled");
+        // Captures CDI bean errors on WebSphere Application Server 8.5.5.12 fixpack APR
+        // PI66630	UnsatisfiedResolutionException thrown in non-CDI environment
+        try{
+          rc.getSingletons().add(new CDIComponentProviderFactory(beanManager, rc, wa));
+          LOGGER.info("CDI support is enabled");
+        }catch(Exception ex)
+        {
+          LOGGER.log(Level.CONFIG, "The CDIComponentProviderFactory failed to initialize", ex);
+        }
     }
 
     private static Object lookup(ServletContext sc) {
@@ -118,7 +125,7 @@ public class CDIComponentProviderFactoryInitializer {
 
             LOGGER.config("The CDI BeanManager is at " + name);
             return beanManager;
-            
+
         } catch (NamingException ex) {
             LOGGER.log(Level.CONFIG, "The CDI BeanManager is not available at " + name, ex);
         }

--- a/jersey-servlet/src/main/java/com/sun/jersey/server/impl/cdi/CDIComponentProviderFactoryInitializer.java
+++ b/jersey-servlet/src/main/java/com/sun/jersey/server/impl/cdi/CDIComponentProviderFactoryInitializer.java
@@ -73,8 +73,8 @@ public class CDIComponentProviderFactoryInitializer {
             return;
         }
 
-        // Captures CDI bean errors on WebSphere Application Server 8.5.5.12 fixpack APR
-        // PI66630	UnsatisfiedResolutionException thrown in non-CDI environment
+        // Captures CDI bean errors on WebSphere Application Server 8.5.5.12 fixpack
+        // See: APR PI66630	UnsatisfiedResolutionException thrown in non-CDI environment
         try{
           rc.getSingletons().add(new CDIComponentProviderFactory(beanManager, rc, wa));
           LOGGER.info("CDI support is enabled");

--- a/jersey-servlet/src/main/java/com/sun/jersey/server/impl/cdi/CDIComponentProviderFactoryInitializer.java
+++ b/jersey-servlet/src/main/java/com/sun/jersey/server/impl/cdi/CDIComponentProviderFactoryInitializer.java
@@ -78,7 +78,7 @@ public class CDIComponentProviderFactoryInitializer {
         try{
           rc.getSingletons().add(new CDIComponentProviderFactory(beanManager, rc, wa));
           LOGGER.info("CDI support is enabled");
-        }catch(Exception ex)
+        }catch(ClassCastException ex)
         {
           LOGGER.log(Level.CONFIG, "The CDIComponentProviderFactory failed to initialize", ex);
         }


### PR DESCRIPTION
# Problem
After upgrading to IBM WebSphere Update 8.5.5.12, startup errors occur due to initialization error of the Jersey (JAX-RS) v.1.17.1 libraries, failing to setup the REST endpoints.
# Reason
The the reason for the problem is that the initialization phase of the Jersey (v1.17.1), is accessing the java:comp/BeanManager from JNDI. 

In the IBM WebSphere 8.5.5.12 Update, the fix **APR PI66630 UnsatisfiedResolutionException thrown in non-CDI environment** , changes the behaviour and returns an object of **javax.naming.Reference**, instead of previously throwing an UnsatisfiedResolutionException. (http://www-01.ibm.com/support/docview.wss?rs=180&uid=swg1PI66630)

This causes a **java.lang.ClassCastException: javax.naming.Reference incompatible with javax.enterprise.inject.spi.BeanManager** in the class **com.sun.jersey.server.impl.cdi.CDIComponentProviderFactory** constructor which is not caught, breaking the Jersey initialization, stopping the subsequent initialization to progress.

See: https://github.com/jersey/jersey-1.x/blob/1.19.3/jersey-servlet/src/main/java/com/sun/jersey/server/impl/cdi/CDIComponentProviderFactory.java#L90

The change in code involved capturing the exception and logging the problem, however still continuing with other initialization, invoked from https://github.com/jersey/jersey-1.x/blob/1.19.3/jersey-servlet/src/main/java/com/sun/jersey/spi/container/servlet/WebComponent.java#L572